### PR TITLE
Fix/fflate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nifti-reader-js",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nifti-reader-js",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "fflate": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nifti-reader-js",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A JavaScript NIfTI file format reader.",
   "main": "src/nifti.js",
   "directories": {

--- a/src/nifti.js
+++ b/src/nifti.js
@@ -120,7 +120,8 @@ nifti.isCompressed = function (data) {
  * @returns {ArrayBuffer}
  */
 nifti.decompress = function (data) {
-    return fflate.decompressSync(new Uint8Array(data)).buffer;
+    const decompressed = fflate.decompressSync(new Uint8Array(data)).buffer;
+    return decompressed
 };
 
 


### PR DESCRIPTION
This fixes some errors seen in niivue when using the recent `0.6.0` nifti-reader-js. The is a patch and has an accompanying version bump to `0.6.1`