### PR TITLE
For ties, give precedence to SForm over QForm to match behavior of SP…

### DIFF
--- a/src/nifti1.js
+++ b/src/nifti1.js
@@ -238,7 +238,7 @@ nifti.NIFTI1.prototype.readHeader = function (data) {
     // Added by znshje on 27/11/2021
     //
     /* See: https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h */
-    if (this.qform_code > 0) {
+    if ((this.qform_code > 0) && (this.sform_code < this.qform_code)) {
         //   METHOD 2 (used when qform_code > 0, which should be the "normal" case):
         //    ---------------------------------------------------------------------
         //    The (x,y,z) coordinates are given by the pixdim[] scales, a rotation


### PR DESCRIPTION
For ties, give precedence to SForm over QForm for affine to match behavior of other tools.