### PR TITLE
Handle Method 0

### DIFF
--- a/src/nifti1.js
+++ b/src/nifti1.js
@@ -238,6 +238,12 @@ nifti.NIFTI1.prototype.readHeader = function (data) {
     // Added by znshje on 27/11/2021
     //
     /* See: https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h */
+    if ((this.qform_code < 1) && (this.sform_code < 1)) {
+        // METHOD 0 (used when both SFORM and QFORM are unknown)
+        this.affine[0][0] = this.pixDims[1];
+        this.affine[1][1] = this.pixDims[2];
+        this.affine[2][2] = this.pixDims[3];
+    }
     if ((this.qform_code > 0) && (this.sform_code < this.qform_code)) {
         //   METHOD 2 (used when qform_code > 0, which should be the "normal" case):
         //    ---------------------------------------------------------------------


### PR DESCRIPTION
This PR fixes an unintended consequence of [PR15](https://github.com/rii-mango/NIFTI-Reader-JS/pull/15) which added NIfTI method 1 to the existing method 2. The specification describes [Method 0](https://nifti.nimh.nih.gov/pub/dist/src/niftilib/nifti1.h) for the case where **neither** the sform or qform is specified. Here is an [example](https://github.com/niivue/niivue/issues/557) of such a dataset. One could argue that an image which does not specify either a qform or sform is necessarily ambiguous with regards to the direction of the dimensions and the origin, so only the voxel size is specified.