### PR TITLE
read nifti with bad extensionFlag

### DIFF
--- a/src/nifti1.ts
+++ b/src/nifti1.ts
@@ -383,18 +383,19 @@ import { Utils } from "./utilities";
 
       this.isHDR = this.magic === String.fromCharCode.apply(null, NIFTI1.MAGIC_NUMBER2);
 
-      let isExtensionCapable = (rawData.byteLength > NIFTI1.MAGIC_COOKIE);
-      if ((!this.isHDR) && (this.vox_offset <= 352))
-        isExtensionCapable = false;
-      if (rawData.byteLength < (352 + 16))
-        isExtensionCapable = false;
-
-      if (isExtensionCapable) {
+      if (rawData.byteLength > NIFTI1.MAGIC_COOKIE) {
         this.extensionFlag[0] = Utils.getByteAt(rawData, 348);
         this.extensionFlag[1] = Utils.getByteAt(rawData, 348 + 1);
         this.extensionFlag[2] = Utils.getByteAt(rawData, 348 + 2);
         this.extensionFlag[3] = Utils.getByteAt(rawData, 348 + 3);
-        if (this.extensionFlag[0]) {
+
+        let isExtensionCapable = true;
+        if ((!this.isHDR) && (this.vox_offset <= 352))
+          isExtensionCapable = false;
+        if (rawData.byteLength <= (352 + 16))
+          isExtensionCapable = false;
+
+        if (isExtensionCapable && this.extensionFlag[0]) {
           // read our extensions
           this.extensions = Utils.getExtensionsAt(
             rawData,

--- a/src/nifti1.ts
+++ b/src/nifti1.ts
@@ -388,7 +388,7 @@ import { Utils } from "./utilities";
         this.extensionFlag[1] = Utils.getByteAt(rawData, 348 + 1);
         this.extensionFlag[2] = Utils.getByteAt(rawData, 348 + 2);
         this.extensionFlag[3] = Utils.getByteAt(rawData, 348 + 3);
-        if (this.extensionFlag[0]) {
+        if (this.vox_offset > 352 && this.extensionFlag[0]) {
           // read our extensions
           this.extensions = Utils.getExtensionsAt(
             rawData,

--- a/src/nifti1.ts
+++ b/src/nifti1.ts
@@ -383,12 +383,18 @@ import { Utils } from "./utilities";
 
       this.isHDR = this.magic === String.fromCharCode.apply(null, NIFTI1.MAGIC_NUMBER2);
 
-      if (rawData.byteLength > NIFTI1.MAGIC_COOKIE) {
+      let isExtensionCapable = (rawData.byteLength > NIFTI1.MAGIC_COOKIE);
+      if ((!this.isHDR) && (this.vox_offset <= 352))
+        isExtensionCapable = false;
+      if (rawData.byteLength < (352 + 16))
+        isExtensionCapable = false;
+
+      if (isExtensionCapable) {
         this.extensionFlag[0] = Utils.getByteAt(rawData, 348);
         this.extensionFlag[1] = Utils.getByteAt(rawData, 348 + 1);
         this.extensionFlag[2] = Utils.getByteAt(rawData, 348 + 2);
         this.extensionFlag[3] = Utils.getByteAt(rawData, 348 + 3);
-        if (this.vox_offset > 352 && this.extensionFlag[0]) {
+        if (this.extensionFlag[0]) {
           // read our extensions
           this.extensions = Utils.getExtensionsAt(
             rawData,


### PR DESCRIPTION
Addresses the issue #35,

The pull request adds a check if the vox_offset is larger than 352, and only then load the extension.