### PR TITLE
Remove extensionByteIndex console.log

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -126,10 +126,6 @@ export class Utils {
         extensionByteIndex + 8,
         extensionByteIndex + esize
       );
-      console.log(
-        "extensionByteIndex: " + (extensionByteIndex + 8) + " esize: " + esize
-      );
-      console.log(edata);
       let extension = new NIFTIEXTENSION(
         esize,
         ecode,


### PR DESCRIPTION
This console.log pollutes the output of downstream consumers such as bids-validator that may be outputting machine readable output (JSON) to stdout. Is there a reason these cannot be removed?