### PR TITLE
Throw exception for readHeader on non-nifti data

### DIFF
--- a/__tests__/nifti-not-nifti.spec.ts
+++ b/__tests__/nifti-not-nifti.spec.ts
@@ -17,7 +17,7 @@ describe('NIFTI-Reader-JS', function () {
       });
 
       it('readHeader() should return null', function () {
-          assert.equal(null, readHeader(data));
+          assert.throws(() => readHeader(data), 'That file does not appear to be NIFTI!');
       });
   });
 });

--- a/src/nifti.ts
+++ b/src/nifti.ts
@@ -123,7 +123,7 @@ export { NIFTIEXTENSION } from "./nifti-extension";
   /**
    * Reads and returns the header object.
    * @param {ArrayBuffer} data
-   * @returns {NIFTI1|NIFTI2|null}
+   * @returns {NIFTI1|NIFTI2}
    */
   export function readHeader(data: ArrayBuffer, isHdrImgPairOK = false) {
     var header = null;
@@ -141,7 +141,7 @@ export { NIFTIEXTENSION } from "./nifti-extension";
     if (header) {
       header.readHeader(data);
     } else {
-      console.error("That file does not appear to be NIFTI!");
+      throw new Error('That file does not appear to be NIFTI!');
     }
 
     return header;

--- a/tests/driver-not-nifti.js
+++ b/tests/driver-not-nifti.js
@@ -23,7 +23,7 @@ describe('NIFTI-Reader-JS', function () {
         });
 
         it('readHeader() should return null', function () {
-            assert.equal(null, nifti.readHeader(data));
+            assert.throws(() => readHeader(data), 'That file does not appear to be NIFTI!');
         });
     });
 });


### PR DESCRIPTION
Prevent console.error when readHeader is called on non-NIFTI files. Instead throw an exception.

See #41